### PR TITLE
Removed unnecessary signTxOutputCustomReader.

### DIFF
--- a/script.go
+++ b/script.go
@@ -6,11 +6,9 @@ package btcscript
 
 import (
 	"bytes"
-	"crypto/rand"
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"io"
 	"time"
 
 	"github.com/conformal/btcec"
@@ -1116,15 +1114,8 @@ func SignatureScript(tx *btcwire.MsgTx, idx int, subscript []byte, hashType SigH
 	return NewScriptBuilder().AddData(sig).AddData(pkData).Script(), nil
 }
 
-func signTxOutput(tx *btcwire.MsgTx, idx int, subScript []byte, hashType SigHashType,
-	key *btcec.PrivateKey) ([]byte, error) {
-
-	return signTxOutputCustomReader(rand.Reader, tx, idx, subScript,
-		hashType, key)
-}
-
-func signTxOutputCustomReader(reader io.Reader, tx *btcwire.MsgTx, idx int,
-	subScript []byte, hashType SigHashType, key *btcec.PrivateKey) ([]byte, error) {
+func signTxOutput(tx *btcwire.MsgTx, idx int, subScript []byte,
+	hashType SigHashType, key *btcec.PrivateKey) ([]byte, error) {
 	parsedScript, err := parseScript(subScript)
 	if err != nil {
 		return nil, fmt.Errorf("cannot parse output script: %v", err)


### PR DESCRIPTION
[`signTxOutputCustomReader`](https://github.com/conformal/btcscript/blob/master/script.go#L1126) has an unused parameter `reader io.Reader` and [`signTxOutput`](https://github.com/conformal/btcscript/blob/master/script.go#L1119) delegats to this function. This patch removes the unnecessary `signTxOutputCustomReader` and just makes `signTxOutput` perform the work. Maybe `signTxOutputCustomReader` is a leftover from a previous implementation?
