### PR TITLE
New AddRaw method to ScriptBuilder

### DIFF
--- a/scriptbuilder.go
+++ b/scriptbuilder.go
@@ -19,8 +19,9 @@ const (
 )
 
 // ScriptBuilder provides a facility for building custom scripts.  It allows
-// you to push opcodes, ints, and data while respecting canonical encoding.  It
-// does not ensure the script will execute correctly.
+// you to push opcodes, ints, and data while respecting canonical encoding,
+// but you can also push raw bytes if you want.  It does not ensure the script
+// will execute correctly.
 //
 // For example, the following would build a 2-of-3 multisig script for usage in
 // a pay-to-script-hash (although in this situation MultiSigScript() would be a
@@ -111,6 +112,13 @@ func (b *ScriptBuilder) AddUint64(val uint64) *ScriptBuilder {
 	}
 
 	return b.AddData(fromInt(new(big.Int).SetUint64(val)))
+}
+
+// AddRaw appends the given byte array, unmodified, to the end
+// of the script.
+func (b *ScriptBuilder) AddRaw(data []byte) *ScriptBuilder {
+	b.script = append(b.script, data...)
+	return b
 }
 
 // Reset resets the script so it has no content.

--- a/scriptbuilder_test.go
+++ b/scriptbuilder_test.go
@@ -248,3 +248,24 @@ func TestScriptBuilderAddData(t *testing.T) {
 		}
 	}
 }
+
+// TestScriptBuilderAddRaw tests that pushing raw bytes to a script via the
+// ScriptBuilder API works as expected.
+func TestScriptBuilderAddRaw(t *testing.T) {
+	builder := btcscript.NewScriptBuilder()
+
+	// Check that AddRaw works when we have an empty script.
+	d1 := bytes.Repeat([]byte{0x01}, 5)
+	builder.AddRaw(d1)
+	if !bytes.Equal(builder.Script(), d1) {
+		t.Errorf("Unexpected script after AddRaw. got: %x, want: %x", builder.Script(), d1)
+	}
+
+	// Check that AddRaw works when we have a non-empty script.
+	d2 := bytes.Repeat([]byte{0x02}, 5)
+	builder.AddRaw(d2)
+	expected := append(d1, d2...)
+	if !bytes.Equal(builder.Script(), expected) {
+		t.Errorf("Unexpected script after AddRaw. got: %x, want: %x", builder.Script(), expected)
+	}
+}


### PR DESCRIPTION
That method just appends the given byte slice to the end of the
script. It's useful if you want to extend an existing script
(e.g. extend a redeem script with raw sigs to get a signature script).
