### PR TITLE
Update script builder for BIP0062 and enforce limits.

### DIFF
--- a/internal_test.go
+++ b/internal_test.go
@@ -18,6 +18,10 @@ import (
 	"github.com/btcsuite/btcwire"
 )
 
+// TstMaxScriptSize makes the internal maxScriptSize constant available to the
+// test package.
+const TstMaxScriptSize = maxScriptSize
+
 // this file is present to export some internal interfaces so that we can
 // test them reliably.
 
@@ -3781,7 +3785,7 @@ func ParseShortForm(script string) ([]byte, error) {
 			builder.script = append(builder.script, bts...)
 		} else if len(tok) >= 2 &&
 			tok[0] == '\'' && tok[len(tok)-1] == '\'' {
-			builder.AddData([]byte(tok[1 : len(tok)-1]))
+			builder.AddFullData([]byte(tok[1 : len(tok)-1]))
 		} else if opcode, ok := ops[tok]; ok {
 			builder.AddOp(opcode.value)
 		} else {
@@ -3789,7 +3793,7 @@ func ParseShortForm(script string) ([]byte, error) {
 		}
 
 	}
-	return builder.Script(), nil
+	return builder.Script()
 }
 
 func TestBitcoindInvalidTests(t *testing.T) {

--- a/scriptbuilder.go
+++ b/scriptbuilder.go
@@ -6,6 +6,7 @@ package btcscript
 
 import (
 	"encoding/binary"
+	"fmt"
 	"math/big"
 )
 
@@ -18,9 +19,21 @@ const (
 	defaultScriptAlloc = 500
 )
 
+// ErrScriptNotCanonical identifies a non-canonical script.  The caller can use
+// a type assertion to detect this error type.
+type ErrScriptNotCanonical string
+
+// Error implements the error interface.
+func (e ErrScriptNotCanonical) Error() string {
+	return string(e)
+}
+
 // ScriptBuilder provides a facility for building custom scripts.  It allows
-// you to push opcodes, ints, and data while respecting canonical encoding.  It
-// does not ensure the script will execute correctly.
+// you to push opcodes, ints, and data while respecting canonical encoding.  In
+// general it does not ensure the script will execute correctly, however any
+// data pushes which would exceed the maximum allowed script engine limits and
+// are therefore guaranteed not to execute will not be pushed and will result in
+// the Script function returning an error.
 //
 // For example, the following would build a 2-of-3 multisig script for usage in
 // a pay-to-script-hash (although in this situation MultiSigScript() would be a
@@ -29,21 +42,70 @@ const (
 // 	builder.AddOp(btcscript.OP_2).AddData(pubKey1).AddData(pubKey2)
 // 	builder.AddData(pubKey3).AddOp(btcscript.OP_3)
 // 	builder.AddOp(btcscript.OP_CHECKMULTISIG)
-// 	fmt.Printf("Final multi-sig script: %x\n", builder.Script())
+// 	script, err := builder.Script()
+// 	if err != nil {
+// 		// Handle the error.
+// 		return
+// 	}
+// 	fmt.Printf("Final multi-sig script: %x\n", script)
 type ScriptBuilder struct {
 	script []byte
+	err    error
 }
 
-// AddOp pushes the passed opcode to the end of the script.
+// AddOp pushes the passed opcode to the end of the script.  The script will not
+// be modified if pushing the opcode would cause the script to exceed the
+// maximum allowed script engine size.
 func (b *ScriptBuilder) AddOp(opcode byte) *ScriptBuilder {
+	if b.err != nil {
+		return b
+	}
+
+	// Pushes that would cause the script to exceed the largest allowed
+	// script size would result in a non-canonical script.
+	if len(b.script)+1 > maxScriptSize {
+		str := fmt.Sprintf("adding an opcode would exceed the maximum "+
+			"allowed canonical script length of %d", maxScriptSize)
+		b.err = ErrScriptNotCanonical(str)
+		return b
+	}
+
 	b.script = append(b.script, opcode)
 	return b
 }
 
-// AddData pushes the passed data to the end of the script.  It automatically
-// chooses canonical opcodes depending on the length of the data. A zero length
-// buffer will lead to a push of empty data onto the stack.
-func (b *ScriptBuilder) AddData(data []byte) *ScriptBuilder {
+// canonicalDataSize returns the number of bytes the canonical encoding of the
+// data will take.
+func canonicalDataSize(data []byte) int {
+	dataLen := len(data)
+
+	// When the data consists of a single number that can be represented
+	// by one of the "small integer" opcodes, that opcode will be instead
+	// of a data push opcode followed by the number.
+	if dataLen == 0 {
+		return 1
+	} else if dataLen == 1 && data[0] <= 16 {
+		return 1
+	} else if dataLen == 1 && data[0] == 0x81 {
+		return 1
+	}
+
+	if dataLen < OP_PUSHDATA1 {
+		return 1 + dataLen
+	} else if dataLen <= 0xff {
+		return 2 + dataLen
+	} else if dataLen <= 0xffff {
+		return 3 + dataLen
+	}
+
+	return 5 + dataLen
+}
+
+// addData is the internal function that actually pushes the passed data to the
+// end of the script.  It automatically chooses canonical opcodes depending on
+// the length of the data.  A zero length buffer will lead to a push of empty
+// data onto the stack (OP_0).  No data limits are enforced with this function.
+func (b *ScriptBuilder) addData(data []byte) *ScriptBuilder {
 	dataLen := len(data)
 
 	// When the data consists of a single number that can be represented
@@ -54,6 +116,9 @@ func (b *ScriptBuilder) AddData(data []byte) *ScriptBuilder {
 		return b
 	} else if dataLen == 1 && data[0] <= 16 {
 		b.script = append(b.script, byte((OP_1-1)+data[0]))
+		return b
+	} else if dataLen == 1 && data[0] == 0x81 {
+		b.script = append(b.script, byte(OP_1NEGATE))
 		return b
 	}
 
@@ -83,8 +148,76 @@ func (b *ScriptBuilder) AddData(data []byte) *ScriptBuilder {
 	return b
 }
 
-// AddInt64 pushes the passed integer to the end of the script.
+// AddFullData should not typically be used by ordinary users as it does not
+// include the checks which prevent data pushes larger than the maximum allowed
+// sizes which leads to scripts that can't be executed.  This is provided for
+// testing purposes such as regression tests where sizes are intentionally made
+// larger than allowed.
+//
+// Use AddData instead.
+func (b *ScriptBuilder) AddFullData(data []byte) *ScriptBuilder {
+	if b.err != nil {
+		return b
+	}
+
+	return b.addData(data)
+}
+
+// AddData pushes the passed data to the end of the script.  It automatically
+// chooses canonical opcodes depending on the length of the data.  A zero length
+// buffer will lead to a push of empty data onto the stack (OP_0) and any push
+// of data greater than MaxScriptElementSize will not modify the script since
+// that is not allowed by the script engine.  Also, the script will not be
+// modified if pushing the data would cause the script to exceed the maximum
+// allowed script engine size.
+func (b *ScriptBuilder) AddData(data []byte) *ScriptBuilder {
+	if b.err != nil {
+		return b
+	}
+
+	// Pushes that would cause the script to exceed the largest allowed
+	// script size would result in a non-canonical script.
+	dataSize := canonicalDataSize(data)
+	if len(b.script)+dataSize > maxScriptSize {
+		str := fmt.Sprintf("adding %d bytes of data would exceed the "+
+			"maximum allowed canonical script length of %d",
+			dataSize, maxScriptSize)
+		b.err = ErrScriptNotCanonical(str)
+		return b
+	}
+
+	// Pushes larger than the max script element size would result in a
+	// script that is not canonical.
+	dataLen := len(data)
+	if dataLen > MaxScriptElementSize {
+		str := fmt.Sprintf("adding a data element of %d bytes would "+
+			"exceed the maximum allowed script element size of %d",
+			dataLen, maxScriptSize)
+		b.err = ErrScriptNotCanonical(str)
+		return b
+	}
+
+	return b.addData(data)
+}
+
+// AddInt64 pushes the passed integer to the end of the script.  The script will
+// not be modified if pushing the data would cause the script to exceed the
+// maximum allowed script engine size.
 func (b *ScriptBuilder) AddInt64(val int64) *ScriptBuilder {
+	if b.err != nil {
+		return b
+	}
+
+	// Pushes that would cause the script to exceed the largest allowed
+	// script size would result in a non-canonical script.
+	if len(b.script)+1 > maxScriptSize {
+		str := fmt.Sprintf("adding an integer would exceed the "+
+			"maximum allow canonical script length of %d",
+			maxScriptSize)
+		b.err = ErrScriptNotCanonical(str)
+		return b
+	}
+
 	// Fast path for small integers and OP_1NEGATE.
 	if val == 0 {
 		b.script = append(b.script, OP_0)
@@ -98,8 +231,24 @@ func (b *ScriptBuilder) AddInt64(val int64) *ScriptBuilder {
 	return b.AddData(fromInt(new(big.Int).SetInt64(val)))
 }
 
-// AddUint64 pushes the passed integer to the end of the script.
+// AddUint64 pushes the passed integer to the end of the script.  The script
+// will not be modified if pushing the data would cause the script to
+// exceed the maximum allowed script engine size.
 func (b *ScriptBuilder) AddUint64(val uint64) *ScriptBuilder {
+	if b.err != nil {
+		return b
+	}
+
+	// Pushes that would cause the script to exceed the largest allowed
+	// script size would result in a non-canonical script.
+	if len(b.script)+1 > maxScriptSize {
+		str := fmt.Sprintf("adding an unsigned integer would exceed "+
+			"the maximum allow canonical script length of %d",
+			maxScriptSize)
+		b.err = ErrScriptNotCanonical(str)
+		return b
+	}
+
 	// Fast path for small integers.
 	if val == 0 {
 		b.script = append(b.script, OP_0)
@@ -116,12 +265,15 @@ func (b *ScriptBuilder) AddUint64(val uint64) *ScriptBuilder {
 // Reset resets the script so it has no content.
 func (b *ScriptBuilder) Reset() *ScriptBuilder {
 	b.script = b.script[0:0]
+	b.err = nil
 	return b
 }
 
-// Script returns the currently built script.
-func (b *ScriptBuilder) Script() []byte {
-	return b.script
+// Script returns the currently built script.  When any errors occured while
+// building the script, the script will be returned up the point of the first
+// error along with the error.
+func (b *ScriptBuilder) Script() ([]byte, error) {
+	return b.script, b.err
 }
 
 // NewScriptBuilder returns a new instance of a script builder.  See


### PR DESCRIPTION
BIP0062 defines specific rules and canonical encodings for data pushes.

The existing script builder code already conformed to all but one of the canonical data push rules that was added after it was originally implemented (adding a single byte of 0x81 must be converted to OP_1NEGATE).  This commit implements that case and expands the existing tests to explicitly cover all cases mentioned in BIP0062.

In addition, as a part of this change, the AddData function has been modified so that any attempt to push more than the maximum script element size bytes (520) in one push or any pushes the would cause the script to exceed the maximum script bytes allowed by the script engine (10000) will result in the final call to the Script function to only return the script up to the point of the first error along with the error.  This change should have little effect on existing callers since they are almost positively not creating scripts which violate these rules as they could never be executed, however it does mean they need to check the new error return.

Since the regression tests intentionally need to be able to exceed that limit, a new function named AddFullData has been added which does not enforce the limits, but still provides canonical encoding of the pushed data.

Note that this commit does not affect consensus rules nor modify the script engine.
